### PR TITLE
add auth header and alerts

### DIFF
--- a/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
+++ b/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
@@ -31,9 +31,13 @@ export default function CSVFileImport({url, title}: CSVFileImportProps) {
   };
 
   const uploadFile = async (e: any) => {
+      const token = localStorage.getItem('authorization_token') || '';
       // Get the presigned URL
       const response = await axios({
         method: 'GET',
+        headers: {
+          Authorization: `Basic ${token}`
+        },
         url,
         params: {
           name: encodeURIComponent(file.name)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,9 +13,17 @@ axios.interceptors.response.use(
     return response;
   },
   function(error) {
-    if (error.response.status === 400) {
-      alert(error.response.data?.data);
+    console.log('err', error)
+    switch (error.response.status) {
+      case 400:
+        alert(error.response.data?.data);
+        break;
+      case 401:
+      case 403:
+        alert(error.response.data?.message);
+        break;
     }
+
     return Promise.reject(error.response);
   }
 );


### PR DESCRIPTION
[Task 7:](https://github.com/rolling-scopes-school/nodejs-aws-tasks/blob/main/task7-lambda%2Bcognito-authorization/task.md#task-7-lambda-authorizer--cognito-authorization)
- [x] 5 - update client application to send Authorization: Basic authorization_token header on import. Client should get authorization_token value from browser localStorage https://developer.mozilla.org/ru/docs/Web/API/Window/localStorage authorization_token = localStorage.getItem('authorization_token')
**Additional (optional) tasks**

- [x] +1 - Client application should display alerts for the responses in 401 and 403 HTTP statuses. This behavior should be added to the nodejs-aws-fe-main/src/index.tsx file

encoded value of **authorization_token** should be saved to localsSorage. Can be done in console:
```
const token = btoa('username:TEST_PASSWORD');
localStorage.setItem('authorization_token', token)
```
